### PR TITLE
Add setup script for i386 build

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# Install packages needed for 32-bit build of Fiwix
+apt-get update
+apt-get install -y build-essential gcc-multilib libc6-dev-i386 lib32gcc-s1


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` to install packages needed for 32-bit build

## Testing
- `make` *(fails: cannot find -lgcc)*