### PR TITLE
Improve build strictness and fix procfs warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-		# fiwix/Makefile
+# fiwix/Makefile
 #
 # Copyright 2018-2022, Jordi Sanfeliu. All rights reserved.
 # Distributed under the terms of the Fiwix License.
@@ -17,7 +17,7 @@ LANG = -std=c89
 CCEXE=gcc
 
 CC = $(CROSS_COMPILE)$(CCEXE) $(ARCH) $(CPU) $(LANG) -D__KERNEL__ $(CONFFLAGS) #-D__DEBUG__
-CFLAGS = -I$(INCLUDE) -O2 -fno-pie -fno-common -ffreestanding -Wall -Wstrict-prototypes #-Wextra -Wno-unused-parameter
+CFLAGS = -I$(INCLUDE) -O2 -fno-pie -fno-common -ffreestanding -Wall -Wstrict-prototypes -Werror -Wa,--noexecstack #-Wextra -Wno-unused-parameter
 
 ifeq ($(CCEXE),gcc)
 LD = $(CROSS_COMPILE)ld
@@ -77,7 +77,7 @@ all:
 	@for n in $(DIRS) ; do (cd $$n ; $(MAKE)) || exit ; done
 ifeq ($(CCEXE),gcc)
 	$(CPP) $(CONFFLAGS) fiwix.ld > $(TMPFILE)
-	$(LD) -N -T $(TMPFILE) $(LDFLAGS) $(OBJS) $(LIBGCC) -o fiwix
+	$(LD) -T $(TMPFILE) $(LDFLAGS) $(OBJS) $(LIBGCC) -o fiwix
 	rm -f $(TMPFILE)
 	nm fiwix | sort | gzip -9c > System.map.gz
 endif

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Features
 
 Compiling
 ---------
-The command needed to build the Fiwix kernel is `make clean ; make`.  This will create the files **fiwix** (the kernel itself) and **System.map.gz** (the symbol table) in the root directory of the source code tree.
+The command needed to build the Fiwix kernel is `./build.sh clean && ./build.sh`.  This will create the files **fiwix** (the kernel itself) and **System.map.gz** (the symbol table) in the root directory of the source code tree.
 
 Before compiling you might want to tweak the kernel configuration by changing the default values in `include/fiwix/config.h` and `include/fiwix/limits.h`.
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# build.sh - simple build wrapper for the Fiwix kernel
+# Usage: ./build.sh [target]
+# Default target is 'all'.
+set -euo pipefail
+
+TARGET="${1:-all}"
+make -j"$(nproc)" "$TARGET"

--- a/fs/procfs/data.c
+++ b/fs/procfs/data.c
@@ -524,8 +524,8 @@ int data_proc_pid_cmdline(char *buffer, __pid_t pid)
 
 	size = 0;
 	if((p = get_proc_by_pid(pid))) {
-		for(n = 0; n < p->argc && (p->argv + n); n++) {
-			argv = p->argv + n;
+               for(n = 0; n < p->argc && p->argv && p->argv[n]; n++) {
+                       argv = &p->argv[n];
 			offset = (int)argv & ~PAGE_MASK;
 			addr = get_mapped_addr(p, (int)argv) & PAGE_MASK;
 			addr = P2V(addr);
@@ -575,8 +575,8 @@ int data_proc_pid_environ(char *buffer, __pid_t pid)
 
 	size = 0;
 	if((p = get_proc_by_pid(pid))) {
-		for(n = 0; n < p->envc && (p->envp + n); n++) {
-			envp = p->envp + n;
+               for(n = 0; n < p->envc && p->envp && p->envp[n]; n++) {
+                       envp = &p->envp[n];
 			offset = (int)envp & ~PAGE_MASK;
 			addr = get_mapped_addr(p, (int)envp) & PAGE_MASK;
 			addr = P2V(addr);

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -5,7 +5,7 @@
 #
 
 .S.o:
-	$(CC) $(CONFFLAGS) -traditional -I$(INCLUDE) -c -o $@ $<
+	$(CC) $(CONFFLAGS) -traditional -Wa,--noexecstack -Werror -I$(INCLUDE) -c -o $@ $<
 .c.o:
 	$(CC) $(CFLAGS) -c -o $@ $<
 


### PR DESCRIPTION
## Summary
- fix `data_proc_pid_cmdline` and `data_proc_pid_environ` loops
- enable `-Werror` and disable execstack in builds
- avoid RWX segment warning by dropping `-N` from linker flags
- update kernel assembly rule for warnings
- add `build.sh` helper and update docs

## Testing
- `./build.sh clean`
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a4c22305883319aaa53ed50ffaac1

## Summary by Sourcery

Improve build strictness, eliminate procfs warnings, and add a build helper script

New Features:
- Add build.sh script to simplify and parallelize kernel builds

Bug Fixes:
- Fix out-of-bounds checks in procfs pid cmdline and environ loops

Enhancements:
- Enable -Werror and -Wa,--noexecstack in compilation and update linker flags to drop -N
- Update kernel Makefile assembly rule to include strict and no-exec-stack flags

Documentation:
- Update README to use build.sh for building the kernel