### PR TITLE
Fix build warnings and add safety checks

### DIFF
--- a/fs/elf.c
+++ b/fs/elf.c
@@ -64,7 +64,8 @@
  */
 static void elf_create_stack(struct binargs *barg, unsigned int *sp, unsigned int str_ptr, int at_base, struct elf32_hdr *elf32_h, unsigned int phdr_addr)
 {
-	unsigned int n, addr;
+       int n;
+       unsigned int addr;
 	char *str;
 
 	/* copy strings */

--- a/fs/procfs/data.c
+++ b/fs/procfs/data.c
@@ -523,9 +523,9 @@ int data_proc_pid_cmdline(char *buffer, __pid_t pid)
 	struct proc *p;
 
 	size = 0;
-	if((p = get_proc_by_pid(pid))) {
-		for(n = 0; n < p->argc && (p->argv + n); n++) {
-			argv = p->argv + n;
+       if((p = get_proc_by_pid(pid))) {
+               for(n = 0; n < p->argc && p->argv && p->argv[n]; n++) {
+                       argv = p->argv + n;
 			offset = (int)argv & ~PAGE_MASK;
 			addr = get_mapped_addr(p, (int)argv) & PAGE_MASK;
 			addr = P2V(addr);
@@ -574,9 +574,9 @@ int data_proc_pid_environ(char *buffer, __pid_t pid)
 	struct proc *p;
 
 	size = 0;
-	if((p = get_proc_by_pid(pid))) {
-		for(n = 0; n < p->envc && (p->envp + n); n++) {
-			envp = p->envp + n;
+       if((p = get_proc_by_pid(pid))) {
+               for(n = 0; n < p->envc && p->envp && p->envp[n]; n++) {
+                       envp = p->envp + n;
 			offset = (int)envp & ~PAGE_MASK;
 			addr = get_mapped_addr(p, (int)envp) & PAGE_MASK;
 			addr = P2V(addr);

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -144,3 +144,5 @@ multiboot_header:			/* multiboot header */
 	/* not reached */
 	jmp	cpu_idle
 
+
+.section .note.GNU-stack,"",@progbits

--- a/kernel/core386.S
+++ b/kernel/core386.S
@@ -719,3 +719,5 @@ _tlbinfo_eax:	.int	0
 _tlbinfo_ebx:	.int	0
 _tlbinfo_ecx:	.int	0
 _tlbinfo_edx:	.int	0
+
+.section .note.GNU-stack,"",@progbits

--- a/kernel/pit.c
+++ b/kernel/pit.c
@@ -18,7 +18,8 @@ void pit_beep_on(void)
 
 void pit_beep_off(unsigned int unused)
 {
-	outport_b(PS2_SYSCTRL_B, inport_b(PS2_SYSCTRL_B) & ~(ENABLE_SDATA | ENABLE_TMR2G));
+       (void)unused;
+       outport_b(PS2_SYSCTRL_B, inport_b(PS2_SYSCTRL_B) & ~(ENABLE_SDATA | ENABLE_TMR2G));
 }
 
 int pit_getcounter0(void)

--- a/kernel/syscalls.c
+++ b/kernel/syscalls.c
@@ -19,9 +19,11 @@
 static int verify_address(int type, const void *addr, unsigned int size)
 {
 #ifdef CONFIG_LAZY_USER_ADDR_CHECK
-	if(!addr) {
-		return -EFAULT;
-	}
+       (void)type;
+       (void)size;
+        if(!addr) {
+                return -EFAULT;
+        }
 #else
 	struct vma *vma;
 	unsigned int start;
@@ -138,14 +140,14 @@ int check_group(struct inode *i)
 		return 0;
 	}
 
-	for(n = 0; n < NGROUPS_MAX; n++) {
-		if(current->groups[n] == -1) {
-			break;
-		}
-		if(current->groups[n] == i->i_gid) {
-			return 0;
-		}
-	}
+       for(n = 0; n < NGROUPS_MAX; n++) {
+               if(current->groups[n] == -1) {
+                       break;
+               }
+               if(current->groups[n] == (int)i->i_gid) {
+                       return 0;
+               }
+       }
 	return 1;
 }
 
@@ -477,7 +479,9 @@ void *syscall_table[] = {
 static void do_bad_syscall(unsigned int num)
 {
 #ifdef __DEBUG__
-	printk("***** (pid %d) system call %d not supported yet *****\n", current->pid, num);
+        printk("***** (pid %d) system call %d not supported yet *****\n", current->pid, num);
+#else
+       (void)num;
 #endif /*__DEBUG__ */
 }
 

--- a/kernel/syscalls/execve.c
+++ b/kernel/syscalls/execve.c
@@ -343,7 +343,12 @@ int sys_execve(const char *filename, char *argv[], char *envp[], int arg4, int a
 int sys_execve(const char *filename, char *argv[], char *envp[], int arg4, int arg5, struct sigcontext *sc)
 #endif /* CONFIG_SYSCALL_6TH_ARG */
 {
-	char *tmp_name;
+       (void)arg4;
+       (void)arg5;
+#ifdef CONFIG_SYSCALL_6TH_ARG
+       (void)arg6;
+#endif
+        char *tmp_name;
 	int n, errno;
 
 #ifdef __DEBUG__

--- a/kernel/syscalls/fork.c
+++ b/kernel/syscalls/fork.c
@@ -36,6 +36,7 @@ int sys_fork(int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, struct 
 int sys_fork(int arg1, int arg2, int arg3, int arg4, int arg5, struct sigcontext *sc)
 #endif /* CONFIG_SYSCALL_6TH_ARG */
 {
+    (void)arg1; (void)arg2; (void)arg3; (void)arg4; (void)arg5;
 	int count, pages;
 	unsigned int n;
 	unsigned int *child_pgdir;

--- a/kernel/syscalls/getcwd.c
+++ b/kernel/syscalls/getcwd.c
@@ -106,7 +106,7 @@ int sys_getcwd(char *buf, __size_t size)
 				if((!diff_dev && d_ptr->d_ino == cur->inode) || (diff_dev && tmp_ino->inode == cur->inode)) {
 					if(strcmp("..", d_ptr->d_name)) {
 						namelength = strlen(d_ptr->d_name);
-						if(marker < namelength + 1) {
+                                               if(marker < (__size_t)namelength + 1) {
 							release_fd(tmp_fd);
 							iput(up);
 							if(cur != current->pwd) {

--- a/kernel/syscalls/iopl.c
+++ b/kernel/syscalls/iopl.c
@@ -37,8 +37,12 @@ int sys_iopl(int level, int arg2, int arg3, int arg4, int arg5, int arg6, struct
 int sys_iopl(int level, int arg2, int arg3, int arg4, int arg5, struct sigcontext *sc)
 #endif /* CONFIG_SYSCALL_6TH_ARG */
 {
+       (void)arg2; (void)arg3; (void)arg4; (void)arg5;
+#ifdef CONFIG_SYSCALL_6TH_ARG
+       (void)arg6;
+#endif
 #ifdef __DEBUG__
-	printk("(pid %d) sys_iopl(%d) -> ", current->pid, level);
+       printk("(pid %d) sys_iopl(%d) -> ", current->pid, level);
 #endif /*__DEBUG__ */
 	if(level > USER_PL) {
 #ifdef __DEBUG__

--- a/kernel/syscalls/mount.c
+++ b/kernel/syscalls/mount.c
@@ -20,7 +20,8 @@
 
 int sys_mount(const char *source, const char *target, const char *fstype, unsigned int flags, const void *data)
 {
-	struct inode *i_source, *i_target;
+       (void)data;
+        struct inode *i_source, *i_target;
 	struct mount *mp;
 	struct filesystems *fs;
 	char *tmp_source, *tmp_target, *tmp_fstype;

--- a/kernel/syscalls/msgctl.c
+++ b/kernel/syscalls/msgctl.c
@@ -100,7 +100,7 @@ int sys_msgctl(int msqid, int cmd, struct msqid_ds *buf)
 			msgque[msqid % MSGMNI] = (struct msqid_ds *)IPC_UNUSED;
 			num_queues--;
 			msg_seq++;
-			if((msqid % MSGMNI) == max_mqid) {
+                       if(((unsigned int)(msqid % MSGMNI)) == max_mqid) {
 				while(max_mqid) {
 					if(msgque[max_mqid] != IPC_UNUSED) {
 						break;

--- a/kernel/syscalls/msgget.c
+++ b/kernel/syscalls/msgget.c
@@ -159,9 +159,9 @@ init:
 	mq->msg_qbytes = MSGMNB;
 	mq->msg_lspid = mq->msg_lrpid = 0;
 	msgque[n] = mq;
-	if(n > max_mqid) {
-		max_mqid = n;
-	}
+       if((unsigned int)n > max_mqid) {
+               max_mqid = n;
+       }
 	num_queues++;
 	return (mq->msg_perm.seq * MSGMNI) + n;
 }

--- a/kernel/syscalls/msgrcv.c
+++ b/kernel/syscalls/msgrcv.c
@@ -91,7 +91,7 @@ int sys_msgrcv(int msqid, void *msgp, __size_t msgsz, int msgtyp, int msgflg)
 		}
 	}
 
-	if(msgsz < m->msg_ts) {
+       if(msgsz < (__size_t)m->msg_ts) {
 		if(!(msgflg & MSG_NOERROR)) {
 			return -E2BIG;
 		}

--- a/kernel/syscalls/readv.c
+++ b/kernel/syscalls/readv.c
@@ -41,9 +41,7 @@ int sys_readv(unsigned int ufd, const struct iovec *iov, int iovcnt)
 		if(!io_read->iov_len) {
 			continue;
 		}
-		if(io_read->iov_len < 0) {
-			return -EINVAL;
-		}
+
 
 		i = fd_table[current->fd[ufd]].inode;
 		if(i->fsop && i->fsop->read) {
@@ -52,9 +50,9 @@ int sys_readv(unsigned int ufd, const struct iovec *iov, int iovcnt)
 			    return errno;
 			}
 			bytes_read += errno;
-			if (errno < io_read->iov_len) {
-				break;
-			}
+                       if ((__size_t)errno < io_read->iov_len) {
+                               break;
+                       }
 		} else {
 			return -EINVAL;
 		}

--- a/kernel/syscalls/reboot.c
+++ b/kernel/syscalls/reboot.c
@@ -25,7 +25,7 @@ int sys_reboot(int magic1, int magic2, int flag)
 	if(!IS_SUPERUSER) {
 		return -EPERM;
 	}
-	if((magic1 != BMAGIC_1) || (magic2 != BMAGIC_2)) {
+       if(((unsigned int)magic1 != BMAGIC_1) || ((unsigned int)magic2 != BMAGIC_2)) {
 		return -EINVAL;
 	}
 	switch(flag) {

--- a/kernel/syscalls/semctl.c
+++ b/kernel/syscalls/semctl.c
@@ -112,7 +112,7 @@ int sys_semctl(int semid, int semnum, int cmd, void *arg)
 			semset[semid % SEMMNI] = (struct semid_ds *)IPC_UNUSED;
 			num_semsets--;
 			sem_seq++;
-			if((semid % SEMMNI) == max_semid) {
+                       if(((unsigned int)(semid % SEMMNI)) == max_semid) {
 				while(max_semid) {
 					if(semset[max_semid] != IPC_UNUSED) {
 						break;
@@ -178,9 +178,10 @@ int sys_semctl(int semid, int semnum, int cmd, void *arg)
 					return s->semncnt;
 				case GETZCNT:
 					return s->semzcnt;
-			}
+                       }
+                       /* fall through */
 
-		case SETVAL:
+               case SETVAL:
 			ss = semset[semid % SEMMNI];
 			if(ss == IPC_UNUSED) {
 				return -EINVAL;

--- a/kernel/syscalls/semget.c
+++ b/kernel/syscalls/semget.c
@@ -206,9 +206,9 @@ init:
 	ss->undo = NULL;
 	ss->sem_nsems = nsems;
 	semset[n] = ss;
-	if(n > max_semid) {
-		max_semid = n;
-	}
+       if((unsigned int)n > max_semid) {
+               max_semid = n;
+       }
 	num_sems += nsems;
 	num_semsets++;
 	return (ss->sem_perm.seq * SEMMNI) + n;

--- a/kernel/syscalls/setfsgid.c
+++ b/kernel/syscalls/setfsgid.c
@@ -15,7 +15,9 @@
 int sys_setfsgid(__gid_t fsgid)
 {
 #ifdef __DEBUG__
-	printk("(pid %d) sys_setfsgid(%d) -> %d\n", current->pid, fsgid);
+       printk("(pid %d) sys_setfsgid(%d) -> %d\n", current->pid, fsgid);
+#else
+       (void)fsgid;
 #endif /*__DEBUG__ */
-	return 0;
+       return 0;
 }

--- a/kernel/syscalls/setfsuid.c
+++ b/kernel/syscalls/setfsuid.c
@@ -15,7 +15,9 @@
 int sys_setfsuid(__uid_t fsuid)
 {
 #ifdef __DEBUG__
-	printk("(pid %d) sys_setfsuid(%d) -> %d\n", current->pid, fsuid);
+       printk("(pid %d) sys_setfsuid(%d) -> %d\n", current->pid, fsuid);
+#else
+       (void)fsuid;
 #endif /*__DEBUG__ */
-	return 0;
+       return 0;
 }

--- a/kernel/syscalls/setregid.c
+++ b/kernel/syscalls/setregid.c
@@ -20,20 +20,20 @@ int sys_setregid(__gid_t gid, __gid_t egid)
 #endif /*__DEBUG__ */
 
 	if(IS_SUPERUSER) {
-		if(egid != (__uid_t)-1) {
-			if(gid != (__uid_t)-1 || (current->egid >= 0 && current->gid != egid)) {
-				current->sgid = egid;
-			}
-			current->egid = egid;
-		}
+               if(egid != (__uid_t)-1) {
+                       if(gid != (__uid_t)-1 || (current->gid != egid)) {
+                               current->sgid = egid;
+                       }
+                       current->egid = egid;
+               }
 		if(gid != (__uid_t)-1) {
 			current->gid = gid;
 		}
 	} else {
-		if(egid != (__uid_t)-1 && (current->gid == egid || current->egid == egid || current->sgid == egid)) {
-			if(gid != (__uid_t)-1 || (current->egid >= 0 && current->gid != egid)) {
-				current->sgid = egid;
-			}
+               if(egid != (__uid_t)-1 && (current->gid == egid || current->egid == egid || current->sgid == egid)) {
+                       if(gid != (__uid_t)-1 || (current->gid != egid)) {
+                               current->sgid = egid;
+                       }
 			current->egid = egid;
 		} else {
 			return -EPERM;

--- a/kernel/syscalls/setreuid.c
+++ b/kernel/syscalls/setreuid.c
@@ -20,20 +20,20 @@ int sys_setreuid(__uid_t uid, __uid_t euid)
 #endif /*__DEBUG__ */
 
 	if(IS_SUPERUSER) {
-		if(euid != (__uid_t)-1) {
-			if(uid != (__uid_t)-1 || (current->euid >= 0 && current->uid != euid)) {
-				current->suid = euid;
-			}
-			current->euid = euid;
-		}
+               if(euid != (__uid_t)-1) {
+                       if(uid != (__uid_t)-1 || (current->uid != euid)) {
+                               current->suid = euid;
+                       }
+                       current->euid = euid;
+               }
 		if(uid != (__uid_t)-1) {
 			current->uid = uid;
 		}
 	} else {
-		if(euid != (__uid_t)-1 && (current->uid == euid || current->euid == euid || current->suid == euid)) {
-			if(uid != (__uid_t)-1 || (current->euid >= 0 && current->uid != euid)) {
-				current->suid = euid;
-			}
+               if(euid != (__uid_t)-1 && (current->uid == euid || current->euid == euid || current->suid == euid)) {
+                       if(uid != (__uid_t)-1 || (current->uid != euid)) {
+                               current->suid = euid;
+                       }
 			current->euid = euid;
 		} else {
 			return -EPERM;

--- a/kernel/syscalls/shmctl.c
+++ b/kernel/syscalls/shmctl.c
@@ -43,7 +43,7 @@ int sys_shmctl(int shmid, int cmd, struct shmid_ds *buf)
 				return errno;
 			}
 			if(cmd == SHM_STAT) {
-				if(shmid > max_segid) {
+                               if((unsigned int)shmid > max_segid) {
 					return -EINVAL;
 				}
 				seg = shmseg[shmid];

--- a/kernel/syscalls/shmdt.c
+++ b/kernel/syscalls/shmdt.c
@@ -24,7 +24,7 @@ int sys_shmdt(char *shmaddr)
 	struct vma *vma;
 	struct shmid_ds *seg;
 	unsigned int addr;
-	int n;
+       unsigned int n;
 
 #ifdef __DEBUG__
 	printk("(pid %d) sys_shmdt(0x%x)\n", current->pid, (int)shmaddr);

--- a/kernel/syscalls/sigreturn.c
+++ b/kernel/syscalls/sigreturn.c
@@ -20,7 +20,9 @@ int sys_sigreturn(unsigned int signum, int arg2, int arg3, int arg4, int arg5, s
 #endif /* CONFIG_SYSCALL_6TH_ARG */
 {
 #ifdef __DEBUG__
-	printk("(pid %d) sys_sigreturn(0x%08x)\n", current->pid, signum);
+       printk("(pid %d) sys_sigreturn(0x%08x)\n", current->pid, signum);
+#else
+       (void)arg2; (void)arg3; (void)arg4; (void)arg5;
 #endif /*__DEBUG__ */
 
 	current->sigblocked &= ~current->sigexecuting;

--- a/kernel/syscalls/umount2.c
+++ b/kernel/syscalls/umount2.c
@@ -20,6 +20,7 @@ static struct resource umount_resource = { 0, 0 };
 
 int sys_umount2(const char *target, int flags)
 {
+       (void)flags;
 	struct inode *i_target;
 	struct mount *mp = NULL;
 	struct filesystems *fs;

--- a/kernel/syscalls/writev.c
+++ b/kernel/syscalls/writev.c
@@ -41,9 +41,6 @@ int sys_writev(int ufd, const struct iovec *iov, int iovcnt)
 		if(fd_table[current->fd[ufd]].flags & O_RDONLY) {
 			return -EBADF;
 		}
-		if(io_write->iov_len < 0) {
-			return -EINVAL;
-		}
 		i = fd_table[current->fd[ufd]].inode;
 		if(i->fsop && i->fsop->write) {
 			errno = i->fsop->write(i, &fd_table[current->fd[ufd]], io_write->iov_base, io_write->iov_len);

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -177,10 +177,12 @@ void del_callout(struct callout_req *creq)
 
 void irq_timer(int num, struct sigcontext *sc)
 {
-	if((++kstat.ticks % HZ) == 0) {
-		CURRENT_TIME++;
-		kstat.uptime++;
-	}
+       (void)num;
+       (void)sc;
+       if((++kstat.ticks % HZ) == 0) {
+               CURRENT_TIME++;
+               kstat.uptime++;
+       }
 
 	timer_bh.flags |= BH_ACTIVE;
 }
@@ -337,7 +339,8 @@ void irq_timer_bh(struct sigcontext *sc)
 
 void do_callouts_bh(struct sigcontext *sc)
 {
-	struct callout *c;
+       (void)sc;
+       struct callout *c;
 	void (*fn)(unsigned int);
 	unsigned int arg;
 

--- a/mm/alloc.c
+++ b/mm/alloc.c
@@ -25,7 +25,7 @@ unsigned int kmalloc(__size_t size)
 
 	/* check if size can be managed by buddy_low */
 	max_size = bl_blocksize[BUDDY_MAX_LEVEL - 1];
-	if(size + sizeof(struct bl_head) <= max_size) {
+       if(size + sizeof(struct bl_head) <= (unsigned int)max_size) {
 		size += sizeof(struct bl_head);
 		return bl_malloc(size);
 	}

--- a/mm/bios_map.c
+++ b/mm/bios_map.c
@@ -155,7 +155,7 @@ void bios_map_init(struct multiboot_mmap_entry *bmmap_addr, unsigned int bmmap_l
 			bmmap = (struct multiboot_mmap_entry *)((unsigned int)bmmap + bmmap->size + sizeof(bmmap->size));
 		}
 		kstat.physical_pages += (1024 >> 2);	/* add the first MB as a whole */
-		if(kstat.physical_pages > (GDT_BASE >> PAGE_SHIFT)) {
+               if(kstat.physical_pages > (int)(GDT_BASE >> PAGE_SHIFT)) {
 			printk("WARNING: detected a total of %dMB of available memory below 4GB.\n", (kstat.physical_pages << 2) / 1024);
 		}
 	} else {
@@ -177,7 +177,7 @@ void bios_map_init(struct multiboot_mmap_entry *bmmap_addr, unsigned int bmmap_l
 	 * Truncate physical memory to upper kernel address space size (1GB or 2GB), since
 	 * currently all memory is permanently mapped there.
 	 */
-	if(kstat.physical_pages > (GDT_BASE >> PAGE_SHIFT)) {
+       if(kstat.physical_pages > (int)(GDT_BASE >> PAGE_SHIFT)) {
 		kstat.physical_pages = (GDT_BASE >> PAGE_SHIFT);
 		printk("WARNING: only up to %dGB of physical memory will be used.\n", GDT_BASE >> 30);
 	}

--- a/mm/buddy_low.c
+++ b/mm/buddy_low.c
@@ -96,7 +96,9 @@ static struct bl_head *allocate(int size)
 	unsigned int addr, paddr;
 	int level;
 
-	for(level = 0; bl_blocksize[level] < size; level++);
+       for(level = 0; bl_blocksize[level] < (unsigned int)size; level++) {
+               ;
+       }
 
 	if(level == BUDDY_MAX_LEVEL) {
 		if((addr = kmalloc(PAGE_SIZE))) {
@@ -147,7 +149,9 @@ unsigned int bl_malloc(__size_t size)
 	struct bl_head *block;
 	int level;
 
-	for(level = 0; bl_blocksize[level] < size; level++);
+       for(level = 0; bl_blocksize[level] < (unsigned int)size; level++) {
+               ;
+       }
 
 	kstat.buddy_low_count[level]++;
 	kstat.buddy_low_mem_requested += bl_blocksize[level];

--- a/mm/fault.c
+++ b/mm/fault.c
@@ -33,6 +33,7 @@ static void send_sigsegv(struct sigcontext *sc)
 
 static int page_protection_violation(struct vma *vma, unsigned int cr2, struct sigcontext *sc)
 {
+       (void)vma;
 	unsigned int *pgdir;
 	unsigned int *pgtbl;
 	unsigned int pde, pte, addr;
@@ -60,9 +61,9 @@ static int page_protection_violation(struct vma *vma, unsigned int cr2, struct s
 			return 1;
 		}
 		current->rss++;
-		memcpy_b((void *)addr, (void *)P2V((page << PAGE_SHIFT)), PAGE_SIZE);
+               memcpy_b((void *)addr, (void *)P2V(((unsigned int)page << PAGE_SHIFT)), PAGE_SIZE);
 		pgtbl[pte] = V2P(addr) | PAGE_PRESENT | PAGE_RW | PAGE_USER;
-		kfree(P2V((page << PAGE_SHIFT)));
+               kfree(P2V(((unsigned int)page << PAGE_SHIFT)));
 		current->rss--;
 		invalidate_tlb();
 		return 0;

--- a/mm/memory.c
+++ b/mm/memory.c
@@ -113,7 +113,7 @@ unsigned int setup_tmp_pgdir(unsigned int magic, unsigned int info)
 	pgtbl = (unsigned int *)addr;
 	memset_b(pgtbl, 0, memksize);
 
-	for(n = 0; n < memksize / sizeof(unsigned int); n++) {
+       for(n = 0; n < (int)(memksize / sizeof(unsigned int)); n++) {
 		pgtbl[n] = (n << PAGE_SHIFT) | PAGE_PRESENT | PAGE_RW;
 		if(!(n % 1024)) {
 			pd = n / 1024;
@@ -208,7 +208,7 @@ int free_page_tables(struct proc *p)
 	int n, count;
 
 	pgdir = (unsigned int *)P2V(p->tss.cr3);
-	for(n = 0, count = 0; n < PD_ENTRIES; n++) {
+       for(n = 0, count = 0; n < (int)PD_ENTRIES; n++) {
 		if((pgdir[n] & (PAGE_PRESENT | PAGE_RW | PAGE_USER)) == (PAGE_PRESENT | PAGE_RW | PAGE_USER)) {
 			kfree(P2V(pgdir[n]) & PAGE_MASK);
 			pgdir[n] = 0;

--- a/mm/page.c
+++ b/mm/page.c
@@ -274,7 +274,7 @@ void release_page(struct page *pg)
 
 int is_valid_page(int page)
 {
-	return (page >= 0 && page < NR_PAGES);
+       return (page >= 0 && page < (int)NR_PAGES);
 }
 
 void invalidate_inode_pages(struct inode *i)
@@ -496,12 +496,13 @@ void reserve_pages(unsigned int from, unsigned int to)
 void page_init(int pages)
 {
 	struct page *pg;
-	unsigned int n, addr;
+       int n;
+       unsigned int addr;
 
 	memset_b(page_table, 0, page_table_size);
 	memset_b(page_hash_table, 0, page_hash_table_size);
 
-	for(n = 0; n < pages; n++) {
+       for(n = 0; n < pages; n++) {
 		pg = &page_table[n];
 		pg->page = n;
 


### PR DESCRIPTION
## Summary
- fix loops in procfs data to avoid pointer warning
- add `.note.GNU-stack` section to assembly
- silence unused parameter warnings across syscalls
- adjust various signed/unsigned comparisons
- restore successful build

## Testing
- `make clean`
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_688a4c22305883319aaa53ed50ffaac1

## Summary by Sourcery

Silence compiler warnings, strengthen pointer safety, and add GNU-stack notes to assembly

Bug Fixes:
- Guard procfs cmdline and environ loops with null checks to prevent unsafe memory access
- Correct semctl switch-case fall-through condition to restore proper behavior

Enhancements:
- Add .note.GNU-stack sections to boot and core386 assembly files

Chores:
- Suppress unused parameter warnings in syscalls and IRQ handlers via void casts
- Normalize signed/unsigned comparisons and adjust variable types across kernel and memory management code