### PR TITLE
Build fix: adjust procfs loops for -Werror

### DIFF
--- a/fs/procfs/data.c
+++ b/fs/procfs/data.c
@@ -524,8 +524,8 @@ int data_proc_pid_cmdline(char *buffer, __pid_t pid)
 
 	size = 0;
 	if((p = get_proc_by_pid(pid))) {
-		for(n = 0; n < p->argc && (p->argv + n); n++) {
-			argv = p->argv + n;
+               for(n = 0; p->argv && n < p->argc && p->argv[n]; n++) {
+                       argv = p->argv + n;
 			offset = (int)argv & ~PAGE_MASK;
 			addr = get_mapped_addr(p, (int)argv) & PAGE_MASK;
 			addr = P2V(addr);
@@ -575,8 +575,8 @@ int data_proc_pid_environ(char *buffer, __pid_t pid)
 
 	size = 0;
 	if((p = get_proc_by_pid(pid))) {
-		for(n = 0; n < p->envc && (p->envp + n); n++) {
-			envp = p->envp + n;
+               for(n = 0; p->envp && n < p->envc && p->envp[n]; n++) {
+                       envp = p->envp + n;
 			offset = (int)envp & ~PAGE_MASK;
 			addr = get_mapped_addr(p, (int)envp) & PAGE_MASK;
 			addr = P2V(addr);


### PR DESCRIPTION
## Summary
- fix pointer comparison loops in procfs `data.c`
- build kernel with `-Werror` to ensure warnings are treated as errors

## Testing
- `make all CFLAGS="-I$(pwd)/include -O2 -fno-pie -fno-common -ffreestanding -Wall -Wstrict-prototypes -Werror"`


------
https://chatgpt.com/codex/tasks/task_e_688a4c22305883319aaa53ed50ffaac1

## Summary by Sourcery

Ensure procfs data code compiles cleanly with -Werror by strengthening pointer loop conditions

Bug Fixes:
- Tighten cmdline loop to verify p->argv and p->argv[n] before use
- Tighten environ loop to verify p->envp and p->envp[n] before use