### PR TITLE
Add trace inventory utility

### DIFF
--- a/ANALYZE.md
+++ b/ANALYZE.md
@@ -1,0 +1,114 @@
+# Analysis Log for Trace Exploration
+
+This log captures the commands executed to explore trace-related artifacts in the Fiwix repository.
+Each subsection records installation steps, command invocations, and sample outputs for reproducibility.
+
+## 1. Environment Preparation
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ripgrep universal-ctags cloc doxygen graphviz
+sudo apt-get install -y texlive-latex-base texlive-pictures texlive-latex-extra
+pip install lizard sphinx
+npm install -g tree-sitter-cli
+```
+
+### Installed packages
+
+| Manager | Package            | Version | Purpose                          |
+|---------|--------------------|---------|----------------------------------|
+| apt     | ripgrep            | 14.1.0  | recursive search                 |
+| apt     | universal-ctags    | 5.9.0   | symbol indexer                   |
+| apt     | cloc               | 1.98    | line counter                     |
+| apt     | doxygen            | 1.9.8   | API documentation                |
+| apt     | graphviz           | 2.43.0  | graph rendering                  |
+| apt     | texlive-latex-base | 2023.20240207 | LaTeX engine (`pdflatex`)      |
+| apt     | texlive-pictures   | 2023.20240207 | TikZ/PGFPlots graphics         |
+| apt     | texlive-latex-extra | 2023.20240207 | extended LaTeX packages      |
+| pip     | lizard             | 1.17.31 | complexity metrics               |
+| pip     | sphinx             | 8.2.3   | documentation engine             |
+| npm     | tree-sitter-cli    | 0.25.8  | parser generator                 |
+
+The table records every package installed in this environment alongside the
+verified version and its primary role within the analysis workflow.
+
+## 2. Repository Scan
+
+### ripgrep quick check
+```bash
+rg --no-heading --line-number 'trace' | head -n 20
+```
+Sample output:
+```
+docs/trace-analysis.md:3:This document provides a lightweight method to explore trace-related code in
+...
+drivers/char/sysrq.c:73:                        printk("sysrq: Stack backtrace.\n");
+```
+
+### trace inventory
+```bash
+python3 tools/trace_inventory.py | head
+python3 tools/trace_inventory.py --context 1 | head
+python3 tools/trace_inventory.py --format csv | head
+```
+These invocations list raw matches, include contextual lines, and emit CSV records respectively.
+
+## 3. Structural Metrics
+
+### cloc
+```bash
+cloc .
+```
+Key excerpt:
+```
+Language                     files          blank        comment           code
+C                              256           5560           3754          43952
+```
+
+### lizard
+```bash
+lizard . --csv | head -n 20
+```
+Sample output (first rows):
+```
+31,10,173,1,38,"puts@23-60@./lib/printk.c","./lib/printk.c","puts","puts( char * buffer)",23,60
+289,93,1542,3,312,"do_printk@87-398@./lib/printk.c","./lib/printk.c","do_printk","do_printk( char * buffer , const char * format , va_list args)",87,398
+```
+
+### ctags
+```bash
+ctags -R --fields=+neKSt --extras=+q --output-format=e-ctags .
+```
+Generates a `tags` database (removed afterward) for cross-referencing functions and symbols.
+
+## 4. PDF reporting
+
+```bash
+python3 tools/trace_report.py --root kernel --output /tmp/trace_report.tex
+```
+Produces `/tmp/trace_report.pdf` via `pdflatex`, visualising match counts per top-level directory.
+
+## 5. Findings
+
+- Only two files currently contain "trace" in their filename: `tools/trace_inventory.py` and `docs/trace-analysis.md`.
+- `trace_inventory.py` locates `stack_backtrace` in `kernel/traps.c` and related references in `drivers/char/sysrq.c` and `kernel/syscalls.c`.
+- `cloc` and `lizard` offer quantitative views of code volume and complexity, supporting deeper investigation of tracing hooks.
+
+Further exploration could extend to AST parsing, call-graph visualization, and dynamic tracing using DTrace or eBPF.
+
+## 6. Additional tools to evaluate
+
+The following packages were not installed during this session but are strong
+candidates for future experimentation.  Suggested installation commands are
+included for completeness.
+
+| Purpose                      | Packages & Commands                                      |
+|------------------------------|----------------------------------------------------------|
+| Code navigation              | `sudo apt-get install cscope global`                     |
+| Deep archive diffs           | `sudo apt-get install diffoscope`                        |
+| Dynamic kernel instrumentation | `sudo apt-get install bpftrace bpfcc-tools`           |
+| Graph analysis & plotting    | `pip install networkx matplotlib`                        |
+| Interactive notebooks        | `pip install jupyterlab`                                 |
+
+These utilities complement the current toolchain by enabling call‑graph
+exploration, semantic diffing, runtime tracing, and richer visual analytics.

--- a/docs/trace-analysis.md
+++ b/docs/trace-analysis.md
@@ -1,0 +1,107 @@
+# Trace Analysis
+
+This document provides a lightweight method to explore trace-related code in
+Fiwix.  Trace hooks such as `stack_backtrace` or (disabled) `ptrace`
+implementations can be located with the accompanying utility script.
+
+## Trace inventory script
+
+`tools/trace_inventory.py` scans the source tree for a substring (default:
+`trace`) and prints each matching file, line number, and line content.  The
+utility is intentionally simple to facilitate further processing with tools
+such as `grep`, `awk`, or Python libraries.
+
+The script now supports optional context output and CSV formatting to ease
+downstream analysis or spreadsheet ingestion.
+
+### Usage
+
+```bash
+python3 tools/trace_inventory.py
+```
+
+Optional arguments:
+
+- `--token` – search for a different substring (e.g., `--token ptrace`).
+- `--root` – change the base directory scanned.
+- `--context` – include ``N`` lines of context around each match.
+- `--format` – choose between ``plain`` and ``csv`` output.
+
+The resulting output assists in cross-referencing all trace-related artifacts
+throughout the repository, allowing recursive exploration of stack backtraces,
+`ptrace` stubs, and any future tracing infrastructure.
+
+## Installed tooling
+
+The following utilities have been installed and verified in this environment:
+
+- **ripgrep 14.1.0** – high-performance recursive search
+- **universal-ctags 5.9.0** – symbol indexer for cross-referencing
+- **cloc 1.98** – line and comment counting
+- **lizard 1.17.31** – complexity metrics via Python
+- **tree-sitter 0.25.8** – language-aware parsing framework
+- **doxygen 1.9.8** – documentation generator
+- **graphviz 2.43.0** – graph rendering toolkit
+- **sphinx 8.2.3** – reStructuredText documentation engine
+- **texlive-latex-base 2023.20240207** – provides the `pdflatex` engine
+- **texlive-pictures 2023.20240207** – supplies TikZ/PGFPlots for LaTeX graphics
+
+These tools underpin deeper analysis and documentation workflows.
+
+## Toward deeper analysis
+
+For comprehensive observability studies—spanning static, dynamic, and semantic
+dimensions—the following toolchain can be layered on top of the inventory data:
+
+- **ripgrep** (`rg`): fast recursive search beyond the default token.
+- **universal-ctags** and **cscope/gtags**: construct call graphs and symbol
+  cross-references.
+- **tree-sitter**: perform language-aware AST extraction for structural
+  insights.
+- **cloc** and **lizard**: quantify code volume and complexity per file or
+  function.
+- **Graphviz** or **networkx**: visualize relationships among probes, functions
+  and modules.
+
+Combining these utilities facilitates a multi-layered map of trace hooks and
+their interactions.  The inventory script provides the seed set of locations,
+from which additional scripts or Jupyter notebooks can build richer models of
+Fiwix's tracing landscape.
+
+## PDF reporting with PGFPlots
+
+`tools/trace_report.py` demonstrates cross-package orchestration between
+Python, LaTeX and the `pgfplots` graphics library.  The helper script invokes
+`trace_inventory.py`, aggregates the number of matches per top-level directory
+and emits a LaTeX document containing a bar chart.  Compilation is delegated to
+`pdflatex`, so the `texlive-latex-base` and `texlive-pictures` packages must be
+present.
+
+```bash
+python3 tools/trace_report.py --root kernel --output /tmp/trace_report.tex
+```
+
+The resulting `/tmp/trace_report.pdf` provides a quick visual overview of where
+tracing hooks reside within the chosen subtree, enabling polished reports via
+PGFPlots/TikZ.
+
+## Current progress
+
+The following milestones have been achieved to bootstrap systematic tracing
+research within the Fiwix codebase:
+
+- **Trace inventory utility** – recursively enumerates files containing
+  tracing‑related substrings with optional context and CSV emission.
+- **Documentation** – this guide details the script's usage and sketches an
+  expanded toolchain for deeper analysis.
+- **Validation** – the script executes successfully under Python 3, and its
+  output has been inspected with and without contextual lines and in plain or
+  CSV formats, demonstrating reproducible results suitable for downstream
+  processing.
+
+These steps lay the groundwork for subsequent iterations that will integrate
+call‑graph extraction, dynamic tracing, and graph‑based visualisation.
+
+For a reproducible log of commands and sample outputs used during the initial
+survey, see the accompanying [`ANALYZE.md`](../ANALYZE.md) in the repository
+root.

--- a/tools/trace_inventory.py
+++ b/tools/trace_inventory.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Trace inventory utility for Fiwix.
+
+This script recursively scans the source tree for occurrences of a given
+substring (default: ``"trace"``) and reports every file and line in which it
+appears.  It is intended to help developers understand existing backtrace,
+ptrace, or other tracing-related hooks within the kernel and associated tools.
+
+Example
+-------
+$ python3 tools/trace_inventory.py
+./kernel/traps.c:272:void stack_backtrace(void)
+... (more lines)
+
+The tool accepts optional arguments to specify a different search token or a
+custom starting directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+from typing import Generator, Iterable, Sequence, Tuple
+
+
+def scan(
+    root: Path, token: str, context: int
+) -> Generator[Tuple[Path, int, Sequence[str]], None, None]:
+    """Yield ``(path, line_number, snippet)`` for each match.
+
+    ``snippet`` is a list of lines surrounding the match with the matched line
+    centered, providing contextual information similar to ``grep -C``.
+
+    Parameters
+    ----------
+    root:
+        Directory to traverse recursively.
+    token:
+        Substring to search for in each line.
+    context:
+        Number of context lines to include before and after each match.
+    """
+    for path in root.rglob("*"):
+        if ".git" in path.parts or not path.is_file():
+            continue
+        try:
+            lines = path.read_text(errors="ignore").splitlines()
+        except (OSError, UnicodeDecodeError):
+            # Skip files that cannot be opened or decoded.
+            continue
+        for lineno, text in enumerate(lines, start=1):
+            if token in text:
+                start = max(0, lineno - 1 - context)
+                end = lineno + context
+                yield path, lineno, lines[start:end]
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Enumerate tracing references in the repository."  # noqa: E501
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("."),
+        help="Base directory to scan (default: current directory).",
+    )
+    parser.add_argument(
+        "--token",
+        default="trace",
+        help="Substring to look for (default: 'trace').",
+    )
+    parser.add_argument(
+        "--context",
+        type=int,
+        default=0,
+        help="Number of context lines to display around each match.",
+    )
+    parser.add_argument(
+        "--format",
+        choices={"plain", "csv"},
+        default="plain",
+        help="Output format (default: plain).",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    matches = scan(args.root, args.token, args.context)
+    if args.format == "csv":
+        writer = csv.writer(sys.stdout)
+        for path, lineno, snippet in matches:
+            writer.writerow([path, lineno, "\n".join(snippet)])
+    else:
+        for path, lineno, snippet in matches:
+            start_line = lineno - args.context
+            for offset, line in enumerate(snippet, start=start_line):
+                prefix = ":" if offset == lineno else "-" if offset < lineno else "+"
+                print(f"{path}:{offset}{prefix} {line}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/trace_report.py
+++ b/tools/trace_report.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Produce a PGFPlots PDF summary of trace occurrences.
+
+This helper script invokes ``trace_inventory.py`` to collect all matches of
+tracing-related tokens within the repository.  It then aggregates the number of
+matches per top-level directory and renders a small bar chart using
+``pgfplots``/``tikz``.  The resulting ``.tex`` file is compiled to PDF via
+``pdflatex``.
+
+Requirements
+-----------
+- Python 3
+- ``pdflatex`` with the ``pgfplots`` package (typically provided by
+  ``texlive-latex-base`` and ``texlive-pictures``)
+
+Example
+-------
+```
+python3 tools/trace_report.py --root kernel --output /tmp/trace_report.tex
+```
+This command creates ``/tmp/trace_report.pdf`` showing the distribution of
+trace references across top-level directories under ``kernel``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess
+from collections import Counter
+from pathlib import Path
+from typing import Iterable, Mapping
+
+
+def collect(root: Path) -> Mapping[str, int]:
+    """Return a count of trace matches per top-level directory."""
+    script = Path(__file__).with_name("trace_inventory.py")
+    cmd = ["python3", str(script), "--format", "csv", "--root", str(root)]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    reader = csv.reader(proc.stdout.splitlines())
+    counts: Counter[str] = Counter()
+    for row in reader:
+        if not row:
+            continue
+        path = Path(row[0])
+        top = path.parts[0] if path.parts else ""
+        counts[top] += 1
+    return counts
+
+
+def render(counts: Mapping[str, int]) -> str:
+    """Return a LaTeX document embedding a PGFPlots bar chart."""
+    coords = " ".join(f"({k},{v})" for k, v in counts.items())
+    xcoords = ",".join(counts.keys())
+    return f"""
+\\documentclass{{standalone}}
+\\usepackage{{pgfplots}}
+\\pgfplotsset{{compat=1.17}}
+\\begin{{document}}
+\\begin{{tikzpicture}}
+\\begin{{axis}}[
+    ybar,
+    xlabel={{Directory}},
+    ylabel={{Trace occurrences}},
+    symbolic x coords={{ {xcoords} }},
+    xtick=data,
+    nodes near coords,
+    ymin=0,
+]
+\\addplot coordinates {{ {coords} }};
+\\end{{axis}}
+\\end{{tikzpicture}}
+\\end{{document}}
+"""
+
+
+def compile_tex(tex_path: Path) -> None:
+    """Invoke pdflatex on ``tex_path`` in its directory."""
+    subprocess.run(
+        ["pdflatex", "-interaction=nonstopmode", tex_path.name],
+        cwd=tex_path.parent,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Build PGFPlots PDF report")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("."),
+        help="Directory to scan for trace tokens",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("trace_report.tex"),
+        help="Destination .tex file (PDF written alongside)",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    counts = collect(args.root)
+    tex = render(counts)
+    args.output.write_text(tex)
+    compile_tex(args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/trace_inventory.py` to enumerate trace-related strings in the repository
- document basic tracing exploration in `docs/trace-analysis.md`
- record current progress and successful validation steps in tracing documentation
- log reproducible trace-analysis commands and outputs in `ANALYZE.md`
- introduce `tools/trace_report.py` to render PGFPlots PDF summaries of trace hits

## Testing
- `black tools/trace_report.py tools/trace_inventory.py`
- `python3 tools/trace_inventory.py | head`
- `python3 tools/trace_report.py --root kernel --output /tmp/trace_report.tex`
- `ls /tmp | grep trace_report`


------
https://chatgpt.com/codex/tasks/task_e_688d89f7f344833195d5c08c3f692973