### PR TITLE
docs: replace build script with ninja configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bochs.log
 qemu.log
 
 run-qemu.log
+.ninja_log

--- a/build.md
+++ b/build.md
@@ -1,0 +1,31 @@
+# Fiwix Kernel Build Guide
+
+This repository previously included a `build.sh` helper script. The
+kernel can now be compiled directly with [Ninja](https://ninja-build.org),
+which orchestrates the existing `Makefile`.
+
+## Prerequisites
+
+Ensure the build tools are installed:
+
+```bash
+sudo apt-get install build-essential ninja-build
+```
+
+## Building
+
+The `build.ninja` file invokes `make` with optimal parallelism. Invoke
+Ninja from the repository root to produce the kernel image:
+
+```bash
+ninja
+```
+
+To clean generated artifacts:
+
+```bash
+ninja clean
+```
+
+Additional `make` targets can be added to `build.ninja` following the
+existing pattern.

--- a/build.ninja
+++ b/build.ninja
@@ -1,0 +1,21 @@
+# build.ninja - Ninja wrapper for the Fiwix kernel build
+# This file replaces the old build.sh script and drives the existing
+# Makefile using Ninja's parallel execution facilities.
+
+# Determine the number of processors at build time for optimal parallelism.
+nprocs = $$(nproc)
+
+rule make
+  command = make -j$nprocs $args
+  description = make $args
+
+# Default kernel image
+build fiwix: make
+  args = all
+
+# Common auxiliary targets
+build clean: make
+  args = clean
+
+# Set the default target so running plain `ninja` builds the kernel.
+default fiwix

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# build.sh - simple build wrapper for the Fiwix kernel
-# Usage: ./build.sh [target]
-# Default target is 'all'.
-set -euo pipefail
-
-TARGET="${1:-all}"
-make -j"$(nproc)" "$TARGET"

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,14 +1,16 @@
 # Shell Script Overview
 
-## build.sh
-Simple wrapper to build the Fiwix kernel with a selectable target using all available processors.
+The legacy `build.sh` wrapper has been replaced by a `build.ninja`
+configuration and accompanying `build.md` guide for Ninja-driven
+builds of the Fiwix kernel.
 
 ## fiwixctl.sh
-Unified helper supporting `setup`, `build`, and `run` commands to manage dependencies, compile the kernel, and launch emulators.
+Unified helper supporting `setup`, `build`, and `run` commands to manage
+dependencies, compile the kernel, and launch emulators.
 
 ## run.sh
-Builds the kernel and runs it under QEMU or Bochs, optionally installing emulator dependencies.
+Builds the kernel and runs it under QEMU or Bochs, optionally installing
+emulator dependencies.
 
 ## setup.sh
 Installs build dependencies and creates an initial disk image for Fiwix.
-


### PR DESCRIPTION
## Summary
- replace `build.sh` with a `build.ninja` file and `build.md` guide
- document new build flow in `docs/scripts.md` and ignore ninja log

## Testing
- `ninja`
- `ninja -n`


------
https://chatgpt.com/codex/tasks/task_e_689b55aa9c54833190859851d2a4b2ea